### PR TITLE
Update Timing.kt

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
+++ b/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
@@ -23,6 +23,20 @@ public inline fun measureTimeMillis(block: () -> Unit): Long {
 }
 
 /**
+ * Executes the given [block] and returns elapsed time in milliseconds.
+ *
+ * @sample samples.system.Timing.measureBlockTimeInMillis
+ */
+public inline fun <R> measureMillis(block: () -> R): Pair<Long, R> {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    val start = System.currentTimeMillis()
+    val ret = block()
+    return Pair<System.currentTimeMillis() - start, ret>
+}
+
+/**
  * Executes the given [block] and returns elapsed time in nanoseconds.
  *
  * @sample samples.system.Timing.measureBlockNanoTime


### PR DESCRIPTION
# Changes

## Background
In a functional language every expression has a return type (including `Unit`)
- The kotlin standard library has `measureTimeMillis()` and `measureNanoTime()` that `measure` time taken by a `block` of code.

```kotlin
fun measureNanoTime(block: () -> Unit): Long {
    val start = System.nanoTime()
    block()
    return System.nanoTime() - start
}
```

- Unfortunately these `measure` methods make an assumption that the `block` returns `Unit`
- so it cannot be used by a block that is an expression that returns a value other than `Unit`

The most common form is when adding timing to a `return` expression

```kotlin
// ...
   return expression;
```

You can't really add timing to this code as the return value is eaten up.

## Complexity
We do have two return values to deal with ... the measured timing and the return value (which can be any type including `Unit`. 

## Solution
The obvious way to represent the two types is a `Pair<Long, T>`.  That's the approach I have chosen.

### Code
```kotlin
fun <R> timeTakenNano(block: () -> R): Pair<R, Long> {
    val start = System.nanoTime()
    val r = block()
    return Pair(r, System.nanoTime() - start)
}
```

### Usage

```kotlin
// ...
val (ret, time) = timeTakenNano { expression }
// ...
log(..., time)
// ...
return ret;
```

### Name etc
The logging example above shows that to log properly you likely need to associate a "name" with the timing. To do this properly it may be fair to associate a name with the timing. Also, the unit used for timing likely needs to be different for each instance. So the return type could be `Tuple` like:

```kotlin
fun <R> timer(name: String = "block", inUnit: TimeUnit = NANOSECONDS, block: () -> R): Tuple3<String, R, Long> {
    val start = System.nanoTime()
    val ret = block()
    val diff = System.nanoTime() - start
    val (time, unit) = convertNanos(diff, inUnit)
    return Tuple3("$name=$time $unit", ret, time)
}
```

The `convertNanos` could be implemented as:

```kotlin
/* Assumes source unit is NANOSECONDS and we only care about s, ms, us and ns */
fun convertNanos(time: Long, toUnit: TimeUnit) =
    when (toUnit) {
        MICROSECONDS -> Pair(NANOSECONDS.toMicros(time), "us")
        MILLISECONDS -> Pair(NANOSECONDS.toMillis(time), "ms")
        SECONDS -> Pair(NANOSECONDS.toSeconds(time), "s")
        else -> Pair(time, "ns")
    }
```